### PR TITLE
Add optional ML tranche-prioritization classifier for ATG Primary Screen

### DIFF
--- a/tools/afvs_apply_ml_classifier_atg-primaryscreen.py
+++ b/tools/afvs_apply_ml_classifier_atg-primaryscreen.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Filters an ATG Primary Screen's tranche-selected collections down to the molecules predicted worth
+docking, using a classifier trained by tools/afvs_train_ml_classifier.py.
+
+Run this after tools/afvs_prepare_atg-primary-screen-todo-files.sh (or its _per_ds sibling) has
+produced a tranche-selected todo file ('<scenario>.todo.<size>', "TrancheCollection LigandCount"
+format), and before tools/afvs_prepare_atg-primary-screen-folders.sh sets up the primary-screen run
+folder. Usage (from the prescreen job's own tools/ directory):
+
+    python3 afvs_apply_ml_classifier_atg-primaryscreen.py \\
+        --todo-file ../output-files/<scenario>.todo.<size> \\
+        --model <path to trained .pt file> \\
+        --output ../output-files/<scenario>.todo.<size>.ml-selected.csv
+
+For every collection listed in --todo-file, this fetches the collection's FULL ligand set (not
+just the sparse prescreen sample -- every ligand of every tranche-selected collection is scored),
+extracts each ligand's SMILES, and scores all of a collection's ligands in a single batched call.
+The output is a CSV in the 'csv_collection_key_ligand' format that all.ctrl's collection_list_type
+already supports (header 'collection_name,collection_number,ligand'), so it can be dropped
+straight into a new all.ctrl's collection_list_file with zero changes needed to afvs_run.py.
+
+Collection fetching reuses this repo's own established mechanisms directly (imported, not
+reimplemented): gen_s3_download_path()/gen_sharedfs_path() from afvs_prepare_workunits.py resolve
+a collection's location under either addressing mode (hash/metatranche) and either storage backend
+(s3/sharedfs); unpack_item()/get_attrs() from tools/templates/afvs_run.py extract a collection's
+ligand files and their SMILES, exactly as the docking engine itself does.
+
+Requires PyTorch and RDKit installed on the host/login instance running this script (not required
+inside the AWS Batch worker container, since this script never runs there).
+
+@author: akshat
+"""
+import os
+import re
+import sys
+import csv
+import json
+import time
+import uuid
+import shutil
+import argparse
+import tempfile
+
+import boto3
+import botocore
+from botocore.config import Config
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates'))
+# ml_classifier.py and afvs_run.py both live in templates/ -- ml_classifier.py so it is auto-bundled
+# into the AWS Batch worker image (which ADDs templates/*.py), afvs_run.py so its unpack_item()/
+# get_attrs() helpers (the exact logic the docking engine itself uses) can be reused here without
+# duplication. This script itself is host-side only and is not Docker-bundled.
+from ml_classifier import load_classifier, filter_smiles_mask  # noqa: E402
+from afvs_run import unpack_item, get_attrs  # noqa: E402
+
+# afvs_prepare_workunits.py lives alongside this script in tools/, importable directly.
+from afvs_prepare_workunits import gen_s3_download_path, gen_sharedfs_path  # noqa: E402
+
+
+COLLECTION_KEY_RE = re.compile(r'(?P<collection_start>.*)_(?P<collection_number>\w+)$')
+MIN_FREE_BYTES = 1024 * 1024 * 1024  # 1 GiB, matching afvs_run.py's own startup free-space check.
+
+
+def read_workflow_config(path):
+    """Reads the already-materialized workflow/config.json (not all.ctrl -- see module docstring
+    in ml_classifier.py and the plan notes: gen_s3_download_path()/gen_sharedfs_path() require
+    config fields, e.g. sharedfs_collection_path, that only exist after afvs_prepare_folders.py's
+    full processing, which config.json already reflects)."""
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def read_todo_file(path):
+    """
+    Reads a tranche-selected todo file ('TrancheCollection LigandCount' per line, matching
+    afvs_prepare_folders.py's own 'standard' collection_list_type parsing convention).
+
+    Returns:
+        list of (collection_name, collection_number) tuples, in file order. collection_number is
+        kept as the exact string from the file (never reformatted/round-tripped through int()),
+        since it must match the tar archive's internal zero-padded directory name exactly.
+    """
+    collections = []
+    with open(path, 'r') as f:
+        for line_number, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(maxsplit=1)
+            if len(parts) < 1:
+                print('WARNING: Skipping malformed todo-file line {}:{}: {}'.format(path, line_number, line))
+                continue
+            collection_key = parts[0]
+            match = COLLECTION_KEY_RE.search(collection_key)
+            if not match:
+                print('WARNING: Could not parse collection key on line {}:{}: {}'.format(
+                    path, line_number, collection_key))
+                continue
+            collections.append((match.group('collection_start'), match.group('collection_number')))
+    return collections
+
+
+def fetch_collection(config, collection_name, collection_number, tmp_dir):
+    """
+    Downloads/copies one collection's tarball and extracts every ligand in it, reusing the exact
+    mechanisms afvs_run.py's own downloader()/untar() pipeline stages use.
+
+    Returns:
+        (ligands_dict_or_None, temp_dir): ligands_dict is None if the fetch or unpack failed
+        (logged, caller should skip this collection); temp_dir is always created and must be
+        cleaned up by the caller regardless of success.
+    """
+    ctx = {'config': config}
+    temp_dir = tempfile.mkdtemp(dir=tmp_dir)
+    local_path = os.path.join(temp_dir, 'tmp.tar.gz')
+
+    try:
+        collection = {
+            'collection_name': collection_name,
+            'collection_number': collection_number,
+            'mode': 'all',  # matches afvs_prepare_folders.py's own literal value for "every ligand"
+        }
+
+        if config['data_storage_mode'] == 's3':
+            s3_bucket = config['object_store_data_bucket']
+            s3_download_path = gen_s3_download_path(ctx, collection_name, collection_number)
+            botoconfig = Config(retries={'max_attempts': 25, 'mode': 'standard'})
+            s3 = boto3.client('s3', config=botoconfig)
+            try:
+                with open(local_path, 'wb') as f:
+                    s3.download_fileobj(s3_bucket, s3_download_path, f)
+            except botocore.exceptions.ClientError as error:
+                print('WARNING: Failed to download {}/{} from S3 ({}). Skipping collection {}_{}.'.format(
+                    s3_bucket, s3_download_path, error, collection_name, collection_number))
+                return None, temp_dir
+        elif config['data_storage_mode'] == 'sharedfs':
+            sharedfs_path = gen_sharedfs_path(ctx, collection_name, collection_number)
+            try:
+                shutil.copyfile(sharedfs_path, local_path)
+            except OSError as error:
+                print('WARNING: Failed to copy {} ({}). Skipping collection {}_{}.'.format(
+                    sharedfs_path, error, collection_name, collection_number))
+                return None, temp_dir
+        else:
+            raise Exception('data_storage_mode must be either s3 or sharedfs (currently: {})'.format(
+                config['data_storage_mode']))
+
+        item = {
+            'temp_dir': temp_dir,
+            'local_path': local_path,
+            'collection_key': '{}_{}'.format(collection_name, collection_number),
+            'collection': collection,
+        }
+        ligands = unpack_item(item)  # side effect: os.chdir(temp_dir) -- see module docstring
+        if ligands is None:
+            print('WARNING: Could not unpack collection {}_{}. Skipping.'.format(
+                collection_name, collection_number))
+            return None, temp_dir
+
+        return ligands, temp_dir
+    except Exception:
+        # The caller only learns temp_dir's path via this function's return value, so if we're
+        # about to propagate an exception instead of returning normally (e.g. a botocore error
+        # that isn't a ClientError subclass, such as EndpointConnectionError), we must clean up
+        # our own temp_dir here -- the caller has no way to do it for us.
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+
+
+def check_disk_space(tmp_dir):
+    stat = shutil.disk_usage(tmp_dir if tmp_dir else tempfile.gettempdir())
+    if stat.free < MIN_FREE_BYTES:
+        raise RuntimeError('Less than 1GB of space free in tmp dir ({}, free: {} bytes). Aborting.'.format(
+            tmp_dir, stat.free))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--todo-file', required=True,
+                        help='Tranche-selected todo file, e.g. ../output-files/<scenario>.todo.<size>')
+    parser.add_argument('--model', required=True, help='Trained classifier .pt file.')
+    parser.add_argument('--workflow-config', default='../workflow/config.json',
+                        help='Path to the prescreen run\'s workflow/config.json.')
+    parser.add_argument('--output', required=True, help='Destination csv_collection_key_ligand CSV.')
+    parser.add_argument('--probability-cutoff', type=float, default=0.5,
+                        help='Minimum predicted probability (exclusive) to keep a ligand.')
+    parser.add_argument('--tmp-dir', default=None,
+                        help='Base directory for per-collection temp extraction (default: system temp).')
+    parser.add_argument('--progress-interval', type=int, default=100,
+                        help='Print progress / check free disk space every N collections.')
+    args = parser.parse_args()
+    if args.progress_interval < 1:
+        parser.error('--progress-interval must be a positive integer.')
+
+    # Resolve every script-owned path to absolute *before* the collection loop: unpack_item()
+    # calls os.chdir() as a side effect, so any relative path referenced later would silently
+    # break after the first collection.
+    todo_file = os.path.abspath(args.todo_file)
+    model_path = os.path.abspath(args.model)
+    workflow_config_path = os.path.abspath(args.workflow_config)
+    output_path = os.path.abspath(args.output)
+    tmp_dir = os.path.abspath(args.tmp_dir) if args.tmp_dir else None
+
+    config = read_workflow_config(workflow_config_path)
+    model, metadata = load_classifier(model_path)
+    fp_radius = metadata.get('fp_radius', 2)
+    fp_nbits = metadata.get('fp_nbits', 1024)
+
+    collections = read_todo_file(todo_file)
+    total_collections = len(collections)
+    print('Loaded {} collections from {}'.format(total_collections, todo_file))
+
+    check_disk_space(tmp_dir)
+
+    output_dir = os.path.dirname(output_path)
+    if output_dir != '' and not os.path.exists(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+    tmp_output_path = '{}.tmp-{}'.format(output_path, uuid.uuid4().hex)
+
+    n_kept_total = 0
+    n_scored_total = 0
+    n_collections_failed = 0
+    original_cwd = os.getcwd()
+
+    try:
+        with open(tmp_output_path, 'w', newline='') as out_f:
+            writer = csv.writer(out_f)
+            writer.writerow(['collection_name', 'collection_number', 'ligand'])
+
+            for counter, (collection_name, collection_number) in enumerate(collections, start=1):
+                collection_temp_dir = None
+                try:
+                    # fetch_collection() itself (not just its return value) must be inside this
+                    # try/except: an unhandled exception here (e.g. a transient network error not
+                    # caught by fetch_collection()'s own narrower except clauses) must not abort
+                    # the whole run -- with potentially thousands of collections and a long
+                    # wall-clock runtime, one bad collection should be logged and skipped, not
+                    # discard all progress on every other collection.
+                    ligands, collection_temp_dir = fetch_collection(config, collection_name, collection_number, tmp_dir)
+                    if ligands is None:
+                        n_collections_failed += 1
+                        continue
+
+                    ligand_names = list(ligands.keys())
+                    smiles_list = []
+                    for ligand_name in ligand_names:
+                        attrs = get_attrs(config['ligand_library_format'], ligands[ligand_name]['path'], attrs=['smi'])
+                        smi = attrs.get('smi', 'N/A')
+                        smiles_list.append('' if smi == 'N/A' else smi)
+
+                    keep_mask, _ = filter_smiles_mask(
+                        model, smiles_list, probability_cutoff=args.probability_cutoff,
+                        fp_radius=fp_radius, fp_nbits=fp_nbits)
+
+                    for ligand_name, keep in zip(ligand_names, keep_mask):
+                        if keep:
+                            writer.writerow([collection_name, collection_number, ligand_name])
+                            n_kept_total += 1
+                    n_scored_total += len(ligand_names)
+                except Exception as e:
+                    n_collections_failed += 1
+                    print('WARNING: Unexpected error processing collection {}_{} ({}). Skipping.'.format(
+                        collection_name, collection_number, e))
+                finally:
+                    # unpack_item() (called inside fetch_collection()) chdir()s into
+                    # collection_temp_dir as a side effect; restore cwd before removing that
+                    # directory (which would otherwise leave the process's cwd pointing at a
+                    # just-deleted directory).
+                    os.chdir(original_cwd)
+                    if collection_temp_dir is not None:
+                        shutil.rmtree(collection_temp_dir, ignore_errors=True)
+
+                if counter % args.progress_interval == 0:
+                    percent_done = (counter / total_collections) * 100 if total_collections > 0 else 100
+                    print('{:.2f}% completed.... ({}/{} collections, {} ligands kept of {} scored, '
+                          '{} collections failed)'.format(
+                              percent_done, counter, total_collections, n_kept_total, n_scored_total,
+                              n_collections_failed))
+                    check_disk_space(tmp_dir)
+
+        os.replace(tmp_output_path, output_path)
+    except BaseException:
+        # Covers both the loop body above and the "with open(...)"/os.replace() calls themselves:
+        # don't leave a partially-written .tmp-<uuid> file behind on a hard failure (disk-full,
+        # Ctrl-C, the disk-space check's RuntimeError, etc.).
+        if os.path.exists(tmp_output_path):
+            os.remove(tmp_output_path)
+        raise
+
+    print('Done. Scored {} ligands across {} collections ({} collections failed to fetch/unpack); '
+          'kept {} above probability_cutoff={}.'.format(
+              n_scored_total, total_collections, n_collections_failed, n_kept_total, args.probability_cutoff))
+    print('Output written to: {}'.format(output_path))

--- a/tools/afvs_prepare_atg-primary-screen-folders.sh
+++ b/tools/afvs_prepare_atg-primary-screen-folders.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #Checking the input arguments
-usage="Usage: afvs_prepare_atg-primary-screen-folders.sh screening_sizes:<size 1>,<size 2>,... replica_counts:<replica count 1>,<replica count 2>,... <docking method>
+usage="Usage: afvs_prepare_atg-primary-screen-folders.sh screening_sizes:<size 1>,<size 2>,... replica_counts:<replica count 1>,<replica count 2>,... <docking method> [ml_classifier_model:<path to trained .pt file>] [ml_classifier_cutoff:<probability cutoff, default 0.5>]
 
 Description: Preparing the folders for the ATG Primary Screens folders. For each docking scenario, and each specified screening size and replica count, one ATG Primary Screen folder will be created. Before running this script, the todo files have to be prepared for each screening size.
 
@@ -9,6 +9,8 @@ Arguments:
     screening_sizes:<size 1>:<size 2>:...: Number of ligands that should be screened in the ATG Primary Screen. Multiple sizes can be spcified if multiple ATG Primary Screens are planned to be run with different screening sizes.
     replica_counts:<replica count 1>,<replica count 2>,... Replica counts that should be used in the ATG Primary Screen. Multiple counts can be spcified if multiple ATG Primary Screens are planned to be run with different replica counts.
     <docking method>: The docking program to be used.
+    ml_classifier_model:<path> (optional): Path to a classifier trained by afvs_train_ml_classifier.py. When given, the ATG Primary Screen is prepared to dock only the molecules (within each tranche-selected collection) predicted worth docking by the classifier, via tools/afvs_apply_ml_classifier_atg-primaryscreen.py. When omitted, behavior is unchanged from today.
+    ml_classifier_cutoff:<float> (optional): Minimum predicted probability (exclusive) to keep a ligand. Default 0.5. Only used if ml_classifier_model: is given.
 "
 
 # Checking arguments
@@ -16,8 +18,8 @@ if [ "${1}" == "-h" ]; then
    echo -e "\n${usage}\n\n"
    exit 0
 fi
-if [ "$#" -ne "3" ]; then
-   echo -e "\nWrong number of arguments. Three arguments are required."
+if [ "$#" -lt "3" ] || [ "$#" -gt "5" ]; then
+   echo -e "\nWrong number of arguments. Three to five arguments are required."
    echo -e "\n${usage}\n\n"
    echo -e "Exiting..."
    exit 1
@@ -28,6 +30,8 @@ fi
 screening_sizes="$1"
 replica_counts="$2"
 docking_scenario_method="$3"
+ml_classifier_model="$4"
+ml_classifier_cutoff="$5"
 
 # Checking argument contents
 # First argument
@@ -53,6 +57,40 @@ else
   exit 1
 fi
 
+# Fourth argument (optional): ML tranche-prioritization classifier
+use_ml_classifier=0
+ml_classifier_model_path=""
+ml_classifier_probability_cutoff="0.5"
+if [ -n "${ml_classifier_model}" ]; then
+  if [[ "$ml_classifier_model" == ml_classifier_model:* ]]; then
+    ml_classifier_model_path=${ml_classifier_model#ml_classifier_model:}
+    # Resolving to an absolute path now, before the "cd ../output-files" below changes the
+    # working directory, since this script is otherwise invoked from the tools/ directory.
+    ml_classifier_model_path=$(realpath "${ml_classifier_model_path}")
+    if [ -z "${ml_classifier_model_path}" ]; then
+      echo "Error: Could not resolve ml_classifier_model: path with realpath. Check that the file exists. Exiting..."
+      exit 1
+    fi
+    use_ml_classifier=1
+  else
+    echo "Error: Fourth argument does not start with 'ml_classifier_model:'. Exiting..."
+    exit 1
+  fi
+fi
+
+# Fifth argument (optional): ML classifier probability cutoff
+if [ -n "${ml_classifier_cutoff}" ]; then
+  if [[ "$ml_classifier_cutoff" == ml_classifier_cutoff:* ]]; then
+    if [ "${use_ml_classifier}" -eq "0" ]; then
+      echo "Warning: ml_classifier_cutoff: was given without ml_classifier_model:, so it has no effect (the ML classifier is not enabled)."
+    fi
+    ml_classifier_probability_cutoff=${ml_classifier_cutoff#ml_classifier_cutoff:}
+  else
+    echo "Error: Fifth argument does not start with 'ml_classifier_cutoff:'. Exiting..."
+    exit 1
+  fi
+fi
+
 # Initial setup
 cd ../output-files
 echo
@@ -60,6 +98,27 @@ echo
 # Prepare next stage foldersparent_dir=$(basename $(dirname $(pwd)))
 for ds in $(cat ../workflow/config.json  | jq -r ".docking_scenario_names" | tr "," " " | tr -d '"\n[]' | tr -s " "); do
   for screening_size in "${screening_sizes[@]}"; do
+
+    # Optional ML tranche-prioritization classifier: run once per (ds, screening_size) pair here
+    # (not once per replica count below -- the ML-selected ligand list is independent of
+    # docking_scenario_replicas), before the replica-count loop that creates the actual run
+    # folders. Skipped if the output already exists, so re-running this script after a partial
+    # failure does not redundantly re-fetch/re-score potentially millions of collections.
+    ml_selected_file=""
+    if [ "${use_ml_classifier}" -eq "1" ]; then
+      ml_selected_file="../output-files/${ds}.todo.${screening_size}.ml-selected.csv"
+      if [ -f "${ml_selected_file}" ]; then
+        echo "ML-filtered ligand list already exists (${ml_selected_file}), skipping re-generation."
+      else
+        echo "Applying the ML tranche-prioritization classifier for docking scenario ${ds}, screening size ${screening_size}..."
+        # ml_classifier_model_path is the one variable in this script resolved via realpath, so
+        # (unlike the other, config-derived tokens used elsewhere here) it can contain spaces --
+        # quoting it (and the other args, as cheap insurance) avoids word-splitting it into
+        # multiple argv tokens.
+        python3 ../tools/afvs_apply_ml_classifier_atg-primaryscreen.py --todo-file "../output-files/${ds}.todo.${screening_size}" --model "${ml_classifier_model_path}" --output "${ml_selected_file}" --probability-cutoff "${ml_classifier_probability_cutoff}"
+      fi
+    fi
+
     for replica_count in "${replica_counts[@]}"; do
       new_af_root_folder="../../atg-primaryscreen_${ds}_${screening_size}_repl${replica_count}"
       echo "Creating new AF directory (${new_af_root_folder}) for the ATG Primary Screen of docking scenrio ${ds} for screening size ${screening_size}, and ${replica_count} replicas"
@@ -86,6 +145,18 @@ for ds in $(cat ../workflow/config.json  | jq -r ".docking_scenario_names" | tr 
       sed -i "s|docking_scenario_replicas=.*|docking_scenario_replicas=${replica_count}|g" ${new_af_root_folder}/tools/templates/all.ctrl
       echo "Setting docking_scenario_methods in the all.ctrl file to ${docking_scenario_method}"
       sed -i "s|docking_scenario_methods=.*|docking_scenario_methods=${docking_scenario_method}|g" ${new_af_root_folder}/tools/templates/all.ctrl
+
+      if [ "${use_ml_classifier}" -eq "1" ]; then
+        echo "Using the ML-filtered ligand list for this ATG Primary Screen (collection_list_type=csv_collection_key_ligand)"
+        cp ${ml_selected_file} ${new_af_root_folder}/tools/templates/atg-ml-selected-ligands.csv
+        # Anchored to the start of the line (unlike the sed substitutions above, which also match
+        # this key inside unrelated comments elsewhere in all.ctrl -- harmless since parse_config()
+        # only recognizes lines starting with the key itself, but there is no reason for these two
+        # new lines to introduce that same avoidable imprecision).
+        sed -i "/^collection_list_type=/s|.*|collection_list_type=csv_collection_key_ligand|g" ${new_af_root_folder}/tools/templates/all.ctrl
+        sed -i "/^collection_list_file=/s|.*|collection_list_file=templates/atg-ml-selected-ligands.csv|g" ${new_af_root_folder}/tools/templates/all.ctrl
+      fi
+
       echo
     done
   done

--- a/tools/afvs_train_ml_classifier.py
+++ b/tools/afvs_train_ml_classifier.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Trains the optional ML tranche-prioritization classifier (see tools/templates/ml_classifier.py) on
+the results of an ATG Prescreen run.
+
+Usage: run an ATG Prescreen as usual (prescreen_mode=1 in all.ctrl), then postprocess it with
+tools/afvs_postprocess_atg-prescreen.sh (AWS/Athena) or
+tools/afvs_postprocess_atg-prescreen.slurm.sh (Slurm/sharedfs). Then, from the prescreen job's own
+tools/ directory, run this script once (a single host-side invocation -- no Slurm/AWS Batch job
+needed, training only takes seconds):
+
+    python3 afvs_train_ml_classifier.py --scenario-name <docking_scenario_name> --model-out <path>
+
+This trains the classifier on the prescreen's per-ligand (SMILES, docking score) data and saves it.
+The saved model is later consumed by tools/afvs_apply_ml_classifier_atg-primaryscreen.py to filter
+the ATG Primary Screen's tranche-selected collections down to the molecules predicted worth
+docking.
+
+Two possible data sources are supported, matching the two postprocessing paths:
+  - AWS/Athena: '<scenario>.ranking.complete.csv.gz' (produced by afvs_get_top_results.py via
+    afvs_postprocess_atg-prescreen.sh), which retains every configured attr_* column including
+    attr_smi.
+  - Slurm/sharedfs: the raw per-collection summary files under
+    'output-files/<scenario>/csv/**/*.csv.gz' (the same files
+    afvs_postprocess_atg-prescreen.slurm.sh itself reads) -- there is no "complete" ranking file
+    on this path, since it never goes through Athena.
+Both sources are read by column NAME (not position) via pandas, since column order/count varies
+with replica count and the print_attrs_in_summary setting in all.ctrl.
+
+Requires PyTorch and RDKit installed on the host/login instance running this script (not required
+inside the AWS Batch worker container, since this script never runs there).
+
+@author: akshat
+"""
+import os
+import sys
+import glob
+import argparse
+
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates'))
+# ml_classifier.py lives in templates/ (not alongside this script) so that it is automatically
+# bundled into the AWS Batch worker image (which ADDs templates/*.py), even though this training
+# script itself is host-side only and is not bundled. This script therefore needs to add
+# templates/ to sys.path explicitly to import it.
+from ml_classifier import train_classifier  # noqa: E402
+
+
+def load_ranking_dataframe(path):
+    """
+    Reads a gzip'd prescreen ranking/summary CSV and validates it has the columns needed for
+    training (attr_smi, score_min), read by name (not position).
+
+    Args:
+        path (str): path to a gzip'd CSV file.
+
+    Returns:
+        pandas.DataFrame
+
+    Raises:
+        Exception: if attr_smi or score_min is missing from the file's columns.
+    """
+    df = pd.read_csv(path, compression='gzip')
+    missing = [col for col in ('attr_smi', 'score_min') if col not in df.columns]
+    if missing:
+        raise Exception(
+            'File {} is missing required column(s) {}. Ensure print_attrs_in_summary in all.ctrl '
+            'includes "smi" for the prescreen run that produced this file.'.format(path, missing))
+    return df
+
+
+def load_training_data(scenario_name, source, ranking_complete_file, raw_csv_glob):
+    """
+    Loads (SMILES, docking score) training pairs from a prescreen run's ranking/summary data.
+
+    Args:
+        scenario_name (str): docking scenario name (used only for default path construction).
+        source (str): 'aws', 'slurm', or 'auto' (try 'aws' first, fall back to 'slurm').
+        ranking_complete_file (str): path to the AWS-path '<scenario>.ranking.complete.csv.gz' file.
+        raw_csv_glob (str): glob pattern for the Slurm-path raw per-collection summary files.
+
+    Returns:
+        (smiles_list, scores_list)
+
+    Raises:
+        Exception: if the requested/auto-detected source has no usable data.
+    """
+    def _from_aws():
+        if not os.path.isfile(ranking_complete_file):
+            raise Exception('AWS ranking file not found: {}'.format(ranking_complete_file))
+        df = load_ranking_dataframe(ranking_complete_file)
+        df = df.dropna(subset=['attr_smi', 'score_min'])
+        print('Loaded {} prescreen rows from {}'.format(len(df), ranking_complete_file))
+        return df['attr_smi'].tolist(), df['score_min'].tolist()
+
+    def _from_slurm():
+        files = sorted(glob.glob(raw_csv_glob, recursive=True))
+        if len(files) == 0:
+            raise Exception('No raw per-collection summary files found matching: {}'.format(raw_csv_glob))
+        frames = [load_ranking_dataframe(f) for f in files]
+        df = pd.concat(frames, ignore_index=True)
+        df = df.dropna(subset=['attr_smi', 'score_min'])
+        print('Loaded {} prescreen rows from {} files matching {}'.format(
+            len(df), len(files), raw_csv_glob))
+        return df['attr_smi'].tolist(), df['score_min'].tolist()
+
+    if source == 'aws':
+        return _from_aws()
+    if source == 'slurm':
+        return _from_slurm()
+
+    # auto: genuinely try the AWS "complete" ranking file first, falling back to raw Slurm csvs on
+    # any failure (not just its absence -- e.g. it could exist but be missing attr_smi/score_min,
+    # or be truncated/corrupt), rather than only pre-checking os.path.isfile().
+    try:
+        return _from_aws()
+    except Exception as aws_error:
+        try:
+            return _from_slurm()
+        except Exception as slurm_error:
+            raise Exception(
+                'No usable prescreen training data found. Tried AWS-path file {} ({}); '
+                'tried Slurm-path glob {} ({}).'.format(
+                    ranking_complete_file, aws_error, raw_csv_glob, slurm_error))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--scenario-name', required=True,
+                        help='Docking scenario name whose prescreen data to train on.')
+    parser.add_argument('--source', choices=['auto', 'aws', 'slurm'], default='auto',
+                        help='Which prescreen data source to read. Default: auto-detect.')
+    parser.add_argument('--ranking-complete-file', default=None,
+                        help='Path to the AWS-path ranking.complete.csv.gz file. '
+                             'Default: ../output-files/<scenario-name>.ranking.complete.csv.gz')
+    parser.add_argument('--raw-csv-glob', default=None,
+                        help='Glob pattern for the Slurm-path raw per-collection summary files. '
+                             'Default: ../output-files/<scenario-name>/csv/**/*.csv.gz')
+    parser.add_argument('--model-out', required=True, help='Path to save the trained model (.pt file).')
+    parser.add_argument('--top-percent', type=float, default=25,
+                        help='Percentage of most-negative-scoring prescreen compounds labeled positive.')
+    parser.add_argument('--seed', type=int, default=42, help='Random seed.')
+    parser.add_argument('--receptor', default=None,
+                        help='Optional receptor identifier stored as model metadata. '
+                             'Defaults to --scenario-name if not given.')
+    args = parser.parse_args()
+
+    ranking_complete_file = args.ranking_complete_file or \
+        '../output-files/{}.ranking.complete.csv.gz'.format(args.scenario_name)
+    raw_csv_glob = args.raw_csv_glob or \
+        '../output-files/{}/csv/**/*.csv.gz'.format(args.scenario_name)
+
+    smiles_list, scores_list = load_training_data(
+        args.scenario_name, args.source, ranking_complete_file, raw_csv_glob)
+
+    if len(smiles_list) == 0:
+        raise Exception('No training data loaded for scenario {}.'.format(args.scenario_name))
+
+    model, history = train_classifier(
+        smiles_list, scores_list, args.model_out,
+        top_percent=args.top_percent, receptor=args.receptor or args.scenario_name, seed=args.seed)
+
+    print('Classifier trained on {} prescreen compounds (best epoch {}, best val loss {:.4f}).'.format(
+        len(smiles_list), history['best_epoch'] + 1, min(history['val_loss'])))
+    print('Saved to: {}'.format(args.model_out))
+    print('To use it for the ATG Primary Screen, pass --model {} to '
+          'afvs_apply_ml_classifier_atg-primaryscreen.py.'.format(args.model_out))

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -23,6 +23,12 @@ RUN yum update -y && yum -y install python3 wget gcc tar make gcc-c++ zlib-devel
 RUN yum install -y libicu libicu-devel
 RUN pip3 install boto3 pandas pyarrow
 
+# Dependencies for the optional ML tranche-prioritization classifier (tools/templates/ml_classifier.py).
+# CPU-only torch wheel: this Dockerfile provisions no GPU AWS Batch compute environments, and the
+# default PyPI torch wheel would pull in unneeded CUDA runtime bloat.
+RUN pip3 install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install rdkit
+
 ADD ./bin /opt/af/tools/bin
 ADD ./templates/*.py /opt/af/tools/templates/
 ADD ./templates/*.sh /opt/af/tools/templates/

--- a/tools/templates/ml_classifier.py
+++ b/tools/templates/ml_classifier.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Optional machine learning classifier for prioritizing candidate compounds before docking.
+
+Implements the "Machine Learning Classifier for Tranche Prioritization" described in the
+AdaptiveFlow manuscript (Methods section): a fully-connected feedforward neural network (FNN)
+trained on Morgan fingerprints and prescreen docking scores, used to filter a large pool of
+undocked candidate compounds down to those predicted to be high-confidence binders before they
+are passed into the docking pipeline.
+
+Used by two standalone, host-side scripts in the ATG-VS pipeline: tools/afvs_train_ml_classifier.py
+(trains a classifier on a prescreen run's docking scores) and
+tools/afvs_apply_ml_classifier_atg-primaryscreen.py (applies a trained classifier to the full
+ligand population of tranche-selected collections, before the ATG Primary Screen run is prepared).
+Neither the classifier nor its training/inference logic is ever imported by afvs_run.py (the core
+docking engine) -- this module has no knowledge of tranches, collections, joblines, or the docking
+engine's runtime state.
+
+@author: akshat
+"""
+import os
+import random
+import uuid
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import TensorDataset, DataLoader
+
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+
+def get_device(device=None):
+    """
+    Resolves the torch device to use, preferring CUDA when available.
+
+    Args:
+        device (str or torch.device or None): explicit device to use. If None, 'cuda' is used
+            when available, else 'cpu'.
+
+    Returns:
+        torch.device
+    """
+    if device is not None:
+        return torch.device(device)
+    return torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+
+def set_seed(seed):
+    """
+    Seeds python's random module, numpy, and torch (including CUDA, if available) for
+    reproducibility.
+
+    Args:
+        seed (int): random seed to use.
+
+    Returns:
+        None
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+class FNNClassifier(nn.Module):
+    """
+    Fully-connected feedforward neural network for binary binding-likelihood classification.
+
+    Architecture (matches the manuscript exactly): an input layer of 1,024 nodes (matching the
+    Morgan fingerprint length), followed by hidden layers of 512, 256, and 128 nodes, each using
+    ReLU activation, followed by a single sigmoid-activated output node representing the
+    predicted binding probability.
+    """
+
+    def __init__(self, input_dim=1024):
+        super(FNNClassifier, self).__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, 512),
+            nn.ReLU(),
+            nn.Linear(512, 256),
+            nn.ReLU(),
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, 1),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def smi_to_fingerprint(smi, radius=2, n_bits=1024):
+    """
+    Converts a SMILES string into a Morgan fingerprint (radius 2, 1024 bits by default, as
+    specified in the manuscript).
+
+    Args:
+        smi (str): SMILES string of the compound.
+        radius (int): Morgan fingerprint radius.
+        n_bits (int): Morgan fingerprint bit-vector length.
+
+    Returns:
+        np.ndarray of shape (n_bits,), dtype float32, or None if the SMILES could not be parsed
+        (including an empty string, which represents a ligand whose SMILES could not be
+        extracted from its structure file).
+    """
+    if not smi:
+        return None
+    mol = Chem.MolFromSmiles(smi)
+    if mol is None:
+        print('WARNING: Invalid SMILES provided, skipping: {}'.format(smi))
+        return None
+    fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=n_bits)
+    arr = np.zeros((n_bits,), dtype=np.float32)
+    for bit in fp.GetOnBits():
+        arr[bit] = 1.0
+    return arr
+
+
+def _fingerprint_all(smiles_list, radius=2, n_bits=1024):
+    """
+    Fingerprints a list of SMILES, dropping any that fail to parse.
+
+    Returns:
+        (kept_indices, fingerprint_matrix) where kept_indices maps rows of the matrix back to
+        indices in the original smiles_list.
+    """
+    kept_indices = []
+    fps = []
+    for i, smi in enumerate(smiles_list):
+        fp = smi_to_fingerprint(smi, radius=radius, n_bits=n_bits)
+        if fp is not None:
+            kept_indices.append(i)
+            fps.append(fp)
+    if len(fps) == 0:
+        return [], np.zeros((0, n_bits), dtype=np.float32)
+    return kept_indices, np.stack(fps, axis=0)
+
+
+def label_by_top_percent(scores, top_percent=25):
+    """
+    Converts docking scores into binary labels via percentile thresholding.
+
+    More negative docking scores indicate better (higher-affinity) binding. The top
+    `top_percent` % of compounds with the most negative scores are labeled 1 ("high-confidence
+    binder"); the rest are labeled 0. This is implemented directly as a percentile cutoff on the
+    raw (ascending) scores to avoid any ambiguity about which "direction" a percentile is taken
+    from.
+
+    Args:
+        scores (np.ndarray): docking scores (more negative = better).
+        top_percent (float): percentage (0-100) of best (most negative) scores to label positive.
+
+    Returns:
+        (labels_ndarray, threshold_value): labels is an int array (0/1) aligned with `scores`,
+            threshold_value is the score cutoff at/below which a compound is labeled positive.
+    """
+    threshold = np.percentile(scores, top_percent)
+    labels = (scores <= threshold).astype(np.int64)
+    return labels, float(threshold)
+
+
+def undersample_majority(X, y, seed=42):
+    """
+    Randomly undersamples the majority class so that both classes are equally represented.
+
+    Args:
+        X (np.ndarray): feature matrix, shape (n_samples, n_features).
+        y (np.ndarray): binary labels (0/1), shape (n_samples,).
+        seed (int): random seed for reproducible undersampling.
+
+    Returns:
+        (X_balanced, y_balanced)
+    """
+    rng = np.random.RandomState(seed)
+    pos_idx = np.where(y == 1)[0]
+    neg_idx = np.where(y == 0)[0]
+
+    if len(pos_idx) == 0 or len(neg_idx) == 0:
+        return X, y
+
+    if len(pos_idx) < len(neg_idx):
+        minority_idx, majority_idx = pos_idx, neg_idx
+    else:
+        minority_idx, majority_idx = neg_idx, pos_idx
+
+    sampled_majority_idx = rng.choice(majority_idx, size=len(minority_idx), replace=False)
+    balanced_idx = np.concatenate([minority_idx, sampled_majority_idx])
+    rng.shuffle(balanced_idx)
+    return X[balanced_idx], y[balanced_idx]
+
+
+def stratified_val_split(X, y, val_fraction=0.10, seed=42):
+    """
+    Splits a (class-balanced) dataset into train/validation partitions, preserving the class
+    balance of each partition.
+
+    Args:
+        X (np.ndarray): feature matrix.
+        y (np.ndarray): binary labels.
+        val_fraction (float): fraction of samples to hold out for validation.
+        seed (int): random seed.
+
+    Returns:
+        (X_train, y_train, X_val, y_val)
+    """
+    rng = np.random.RandomState(seed)
+    train_idx_parts = []
+    val_idx_parts = []
+    for cls in np.unique(y):
+        cls_idx = np.where(y == cls)[0]
+        rng.shuffle(cls_idx)
+        n_val = max(1, int(round(len(cls_idx) * val_fraction))) if len(cls_idx) > 1 else 0
+        val_idx_parts.append(cls_idx[:n_val])
+        train_idx_parts.append(cls_idx[n_val:])
+
+    train_idx = np.concatenate(train_idx_parts)
+    val_idx = np.concatenate(val_idx_parts)
+    rng.shuffle(train_idx)
+    rng.shuffle(val_idx)
+    return X[train_idx], y[train_idx], X[val_idx], y[val_idx]
+
+
+def train_classifier(smiles_list, scores, model_out_path, top_percent=25, val_fraction=0.10,
+                      batch_size=256, max_epochs=50, patience=5, learning_rate=0.001,
+                      seed=42, receptor=None, fp_radius=2, fp_nbits=1024, device=None,
+                      verbose=True):
+    """
+    Trains the FNN tranche-prioritization classifier on prescreen docking results.
+
+    Args:
+        smiles_list (list of str): SMILES strings of the prescreen compounds.
+        scores (list or np.ndarray of float): docking scores aligned with smiles_list (more
+            negative = better binder), as produced by a prescreen run (see
+            afvs_train_ml_classifier.py, which parses these out of AdaptiveFlow-VS's prescreen
+            ranking/summary files).
+        model_out_path (str): path to save the trained model (.pt file).
+        top_percent (float): percentage of most-negative-scoring prescreen compounds labeled as
+            positive ("high-confidence binder"). Default 25, per the manuscript.
+        val_fraction (float): validation split fraction. Default 0.10, per the manuscript.
+        batch_size (int): training batch size. Default 256, per the manuscript.
+        max_epochs (int): maximum number of training epochs. Default 50, per the manuscript.
+        patience (int): early-stopping patience (epochs without validation-loss improvement).
+            Default 5, per the manuscript.
+        learning_rate (float): Adam learning rate. Default 0.001, per the manuscript.
+        seed (int): random seed for undersampling, splitting, and model initialization.
+        receptor (str or None): optional receptor identifier/path stored as metadata, so a
+            saved model can later be associated with the target it was trained for.
+        fp_radius (int): Morgan fingerprint radius.
+        fp_nbits (int): Morgan fingerprint length.
+        device (str or None): torch device override. Auto-detected (CUDA if available) if None.
+        verbose (bool): whether to print per-epoch training/validation loss.
+
+    Returns:
+        (model, history): the trained FNNClassifier (in eval mode, on `device`), and a dict with
+            keys 'train_loss', 'val_loss' (lists, one entry per epoch actually run), and
+            'best_epoch'.
+
+    Raises:
+        Exception: if fewer than 2 classes are present after labeling (cannot train a
+            classifier), or if no SMILES in the prescreen data could be parsed.
+    """
+    set_seed(seed)
+    device = get_device(device)
+
+    scores = np.asarray(scores, dtype=np.float32)
+    kept_indices, X_all = _fingerprint_all(smiles_list, radius=fp_radius, n_bits=fp_nbits)
+    if X_all.shape[0] == 0:
+        raise Exception('No valid SMILES found in prescreen data.')
+    scores_kept = scores[kept_indices]
+
+    labels, threshold = label_by_top_percent(scores_kept, top_percent=top_percent)
+    if len(np.unique(labels)) < 2:
+        raise Exception('Only one class present after labeling (top_percent={}); '
+                         'cannot train a binary classifier. Provide more diverse prescreen '
+                         'docking scores.'.format(top_percent))
+
+    X_bal, y_bal = undersample_majority(X_all, labels, seed=seed)
+    X_train, y_train, X_val, y_val = stratified_val_split(X_bal, y_bal, val_fraction=val_fraction,
+                                                           seed=seed)
+
+    train_ds = TensorDataset(torch.from_numpy(X_train), torch.from_numpy(y_train.astype(np.float32)))
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+
+    X_val_t = torch.from_numpy(X_val).to(device)
+    y_val_t = torch.from_numpy(y_val.astype(np.float32)).to(device)
+
+    model = FNNClassifier(input_dim=fp_nbits).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+    loss_fn = nn.BCELoss()
+
+    history = {'train_loss': [], 'val_loss': []}
+    best_val_loss = float('inf')
+    best_state_dict = None
+    best_epoch = 0
+    epochs_without_improvement = 0
+
+    for epoch in range(max_epochs):
+        model.train()
+        epoch_train_losses = []
+        for xb, yb in train_loader:
+            xb, yb = xb.to(device), yb.to(device)
+            optimizer.zero_grad()
+            preds = model(xb).squeeze(1)
+            loss = loss_fn(preds, yb)
+            loss.backward()
+            optimizer.step()
+            epoch_train_losses.append(loss.item())
+        train_loss = float(np.mean(epoch_train_losses))
+
+        model.eval()
+        with torch.no_grad():
+            val_preds = model(X_val_t).squeeze(1)
+            val_loss = float(loss_fn(val_preds, y_val_t).item())
+
+        history['train_loss'].append(train_loss)
+        history['val_loss'].append(val_loss)
+        if verbose:
+            print('Epoch {}/{} - train_loss: {:.4f} - val_loss: {:.4f}'.format(
+                epoch + 1, max_epochs, train_loss, val_loss))
+
+        if val_loss < best_val_loss:
+            best_val_loss = val_loss
+            best_state_dict = {k: v.clone() for k, v in model.state_dict().items()}
+            best_epoch = epoch
+            epochs_without_improvement = 0
+        else:
+            epochs_without_improvement += 1
+            if epochs_without_improvement >= patience:
+                if verbose:
+                    print('Early stopping at epoch {} (patience={})'.format(epoch + 1, patience))
+                break
+
+    model.load_state_dict(best_state_dict)
+    model.eval()
+
+    metadata = {
+        'input_dim': fp_nbits,
+        'fp_radius': fp_radius,
+        'fp_nbits': fp_nbits,
+        'top_percent': top_percent,
+        'train_threshold': threshold,
+        'seed': seed,
+        'receptor': receptor,
+        'best_epoch': best_epoch,
+        'best_val_loss': best_val_loss,
+    }
+    save_classifier(model, model_out_path, metadata)
+    history['best_epoch'] = best_epoch
+
+    return model, history
+
+
+def save_classifier(model, out_path, metadata):
+    """
+    Saves a trained FNNClassifier's weights and associated metadata to disk.
+
+    Args:
+        model (FNNClassifier): the trained model.
+        out_path (str): destination path (.pt file). Parent directories are created if needed.
+        metadata (dict): metadata to store alongside the weights (fingerprint params, threshold,
+            seed, receptor, etc.), retrievable via load_classifier().
+
+    Returns:
+        None
+
+    Note:
+        Written atomically (temp file + os.replace) so that concurrent readers -- e.g. many
+        independent invocations of the ML filtering script across different docking scenarios --
+        never observe a partially-written checkpoint, even if this function is called again
+        (retraining) while a previous filtering run using the model is still in progress.
+    """
+    out_dir = os.path.dirname(out_path)
+    if out_dir != '' and not os.path.exists(out_dir):
+        os.makedirs(out_dir, exist_ok=True)
+    checkpoint = {'state_dict': model.state_dict()}
+    checkpoint.update(metadata)
+
+    tmp_path = '{}.tmp-{}'.format(out_path, uuid.uuid4().hex)
+    torch.save(checkpoint, tmp_path)
+    os.replace(tmp_path, out_path)
+
+
+def load_classifier(model_path, device=None):
+    """
+    Loads a previously trained FNNClassifier from disk.
+
+    Args:
+        model_path (str): path to a .pt file created by save_classifier()/train_classifier().
+        device (str or None): torch device override. Auto-detected (CUDA if available) if None.
+
+    Returns:
+        (model, metadata): the FNNClassifier in eval mode on `device`, and the metadata dict
+            saved alongside the weights.
+
+    Raises:
+        Exception: if model_path does not exist or is not a file.
+    """
+    if not os.path.isfile(model_path):
+        raise Exception('Model path {} not found.'.format(model_path))
+    device = get_device(device)
+    checkpoint = torch.load(model_path, map_location=device)
+    input_dim = checkpoint.get('input_dim', 1024)
+    model = FNNClassifier(input_dim=input_dim).to(device)
+    model.load_state_dict(checkpoint['state_dict'])
+    model.eval()
+    metadata = {k: v for k, v in checkpoint.items() if k != 'state_dict'}
+    return model, metadata
+
+
+def predict_proba(model, smiles_list, device=None, fp_radius=2, fp_nbits=1024):
+    """
+    Predicts binding probability for a list of SMILES using a trained classifier.
+
+    Args:
+        model (FNNClassifier): a trained (eval-mode) model, as returned by load_classifier() or
+            train_classifier().
+        smiles_list (list of str): SMILES strings to score.
+        device (str or None): torch device override. Auto-detected (CUDA if available) if None.
+        fp_radius (int): Morgan fingerprint radius (must match training).
+        fp_nbits (int): Morgan fingerprint length (must match training).
+
+    Returns:
+        list of (smi, probability_or_None), aligned with `smiles_list` in order. Invalid or empty
+        SMILES yield a probability of None.
+    """
+    device = get_device(device)
+    model = model.to(device)
+    model.eval()
+
+    kept_indices, X = _fingerprint_all(smiles_list, radius=fp_radius, n_bits=fp_nbits)
+    results = [None] * len(smiles_list)
+
+    if X.shape[0] > 0:
+        with torch.no_grad():
+            X_t = torch.from_numpy(X).to(device)
+            probs = model(X_t).squeeze(1).cpu().numpy()
+        for local_i, orig_i in enumerate(kept_indices):
+            results[orig_i] = float(probs[local_i])
+
+    return [(smi, results[i]) for i, smi in enumerate(smiles_list)]
+
+
+def filter_smiles_mask(model, smiles_list, probability_cutoff=0.5, device=None,
+                        fp_radius=2, fp_nbits=1024):
+    """
+    Scores a list of SMILES and returns a keep/discard mask, for filtering an in-memory batch of
+    candidate ligands before they are submitted for docking.
+
+    Ligands whose SMILES could not be extracted/parsed (probability is None) are always treated
+    as discards (fail-closed) -- if the ML classifier is enabled, an unscoreable ligand is an
+    unexpected state and it is safer to not spend docking budget on it than to silently bypass
+    the filter the user opted into.
+
+    Args:
+        model (FNNClassifier): a trained (eval-mode) model.
+        smiles_list (list of str): SMILES strings to score.
+        probability_cutoff (float): minimum predicted probability (exclusive) to retain a
+            compound for docking. Default 0.5, per the manuscript.
+        device (str or None): torch device override. Auto-detected (CUDA if available) if None.
+        fp_radius (int): Morgan fingerprint radius (must match training).
+        fp_nbits (int): Morgan fingerprint length (must match training).
+
+    Returns:
+        (keep_mask, probabilities): keep_mask is a list of bool aligned with smiles_list (True =
+            retain for docking); probabilities is the aligned list of predicted probabilities
+            (None for compounds with invalid/empty SMILES, which are always discarded).
+    """
+    scored = predict_proba(model, smiles_list, device=device, fp_radius=fp_radius, fp_nbits=fp_nbits)
+    keep_mask = [prob is not None and prob > probability_cutoff for _, prob in scored]
+    probabilities = [prob for _, prob in scored]
+    return keep_mask, probabilities
+
+
+if __name__ == '__main__':
+    # Synthetic self-test: exercises train -> save -> load -> filter end-to-end without
+    # requiring any real docking runs. Fabricated docking scores are correlated with a simple
+    # RDKit descriptor (heavy-atom count) plus noise, so there is real learnable signal.
+    from rdkit.Chem import Descriptors
+
+    SCRATCH_DIR = './ml_classifier_selftest'
+    os.makedirs(SCRATCH_DIR, exist_ok=True)
+
+    demo_smiles = [
+        'CCO', 'CCCO', 'CCCCO', 'CCCCCO', 'CCN', 'CCCN', 'CCCCN', 'c1ccccc1', 'c1ccccc1C',
+        'c1ccccc1CC', 'c1ccccc1O', 'c1ccccc1N', 'CC(=O)O', 'CC(=O)N', 'CC(=O)OC', 'CC(=O)OCC',
+        'CCOC(=O)C', 'c1ccncc1', 'c1ccoc1', 'c1ccsc1', 'C1CCCCC1', 'C1CCCCC1O', 'C1CCCCC1N',
+        'CC(C)C', 'CC(C)CC', 'CC(C)(C)C', 'C1=CC(=CC=C1CSCC2C(C(C(O2)N3C=NC4=C(N=CN=C43)N)O)O)Cl',
+        'CCCCCCCCCC', 'c1ccc2ccccc2c1', 'c1ccc2[nH]ccc2c1', 'CC(N)C(=O)O', 'NC(Cc1ccccc1)C(=O)O',
+        'CC1CCC(C)CC1', 'OC1CCCCC1', 'NC1CCCCC1', 'FC1=CC=CC=C1', 'ClC1=CC=CC=C1',
+        'BrC1=CC=CC=C1', 'CCOCC', 'CCSCC', 'CCC(=O)CC', 'CCC(=O)NCC', 'c1ccc(cc1)C(=O)O',
+        'c1ccc(cc1)C(=O)N', 'CC(=O)Nc1ccccc1', 'COc1ccccc1', 'CSc1ccccc1', 'CNc1ccccc1',
+        'CC1=CC=CC=C1C', 'CC1=CC=CC=C1CC', 'NCCc1ccccc1', 'OCCc1ccccc1', 'CC(C)Oc1ccccc1',
+    ]
+
+    rng = np.random.RandomState(42)
+
+    def fabricate_score(smi):
+        mol = Chem.MolFromSmiles(smi)
+        heavy_atoms = Descriptors.HeavyAtomCount(mol)
+        return -1.0 * heavy_atoms + rng.normal(0, 1.5)
+
+    all_scores = [fabricate_score(s) for s in demo_smiles]
+
+    prescreen_smiles = demo_smiles[:30]
+    prescreen_scores = all_scores[:30]
+    candidate_smiles = demo_smiles[30:] + ['not_a_smiles', 'also_invalid???', '']
+
+    model_path = os.path.join(SCRATCH_DIR, 'classifier.pt')
+
+    print('--- Step 1: training classifier on synthetic prescreen data ---')
+    model, history = train_classifier(prescreen_smiles, prescreen_scores, model_path,
+                                       receptor='receptor.pdbqt', seed=42, verbose=True)
+    assert os.path.exists(model_path), 'Model file was not written.'
+    assert history['best_epoch'] <= 49, 'Training ran past max_epochs=50.'
+
+    labels_check, _ = label_by_top_percent(np.array(prescreen_scores, dtype=np.float32), top_percent=25)
+    frac_positive = labels_check.mean()
+    print('Fraction of prescreen labeled positive: {:.2f} (expected ~0.25)'.format(frac_positive))
+    assert 0.10 < frac_positive < 0.40, 'Positive label fraction far from expected ~25%.'
+
+    print('--- Step 2: loading saved classifier and checking architecture ---')
+    loaded_model, metadata = load_classifier(model_path)
+    shapes = [tuple(p.shape) for p in loaded_model.net.parameters() if p.dim() == 2]
+    expected_shapes = [(512, 1024), (256, 512), (128, 256), (1, 128)]
+    assert shapes == expected_shapes, 'Unexpected layer shapes: {}'.format(shapes)
+    print('Layer shapes match spec: {}'.format(shapes))
+
+    print('--- Step 3: filtering an in-memory candidate batch ---')
+    keep_mask, probabilities = filter_smiles_mask(loaded_model, candidate_smiles, probability_cutoff=0.5)
+    n_kept = sum(keep_mask)
+    print('Filter stats: kept {}/{} candidates.'.format(n_kept, len(candidate_smiles)))
+    assert n_kept < len(candidate_smiles), 'Expected some candidates to be filtered out.'
+    for smi, keep, prob in zip(candidate_smiles, keep_mask, probabilities):
+        if keep:
+            assert prob is not None and prob > 0.5, '{} kept but prob={}'.format(smi, prob)
+        else:
+            assert prob is None or prob <= 0.5, '{} dropped but prob={}'.format(smi, prob)
+    assert keep_mask[candidate_smiles.index('')] is False, 'Empty SMILES must always be discarded (fail-closed).'
+    print('Threshold correctness verified for all candidates (kept iff prob > 0.5); empty SMILES fail-closed.')
+
+    print('--- Step 4: determinism check (retrain with identical seed) ---')
+    model_path_2 = os.path.join(SCRATCH_DIR, 'classifier_run2.pt')
+    model_2, _ = train_classifier(prescreen_smiles, prescreen_scores, model_path_2,
+                                   receptor='receptor.pdbqt', seed=42, verbose=False)
+    for (n1, p1), (n2, p2) in zip(model.named_parameters(), model_2.named_parameters()):
+        assert torch.equal(p1, p2), 'Parameter {} differs between identical-seed runs.'.format(n1)
+    print('Determinism verified: identical seeds produce bit-identical weights.')
+
+    print('--- Step 5: invalid SMILES handling ---')
+    invalid_present = any(prob is None for _, prob in predict_proba(loaded_model, ['not_a_smiles', 'CCO']))
+    assert invalid_present, 'Invalid SMILES should yield probability None.'
+    print('Invalid SMILES correctly skipped with a warning rather than raising.')
+
+    print('\nAll self-tests passed.')

--- a/tutorials/tutorial-1-afvs-on-aws/preparing-the-atg-primary-screen.md
+++ b/tutorials/tutorial-1-afvs-on-aws/preparing-the-atg-primary-screen.md
@@ -49,3 +49,25 @@ Then, we prepare the workflow in the same way as we did for the ATG Prescreen:
 
 It can happen that this command requires to be run as root, depending on your specific setup. Please try `sudo ./afvs_build_docker.sh` in case the above command fails. The command ./afvs\_prepare\_workunits.py will print the total number of work units. Please remember this number, as it is needed in the next section.&#x20;
 
+## Optional: ML Tranche-Prioritization Classifier
+
+Instead of docking every ligand of every tranche-selected collection, you can optionally train a machine learning classifier on the ATG Prescreen's docking results and use it to keep, within each selected collection, only the ligands it predicts are worth docking. This can substantially reduce the number of ligands actually docked in the ATG Primary Screen.
+
+First, train the classifier on the postprocessed ATG Prescreen results. This is a one-time, host-side command that only takes seconds to run (no AWS Batch job needed), to be run in the `tools` folder of the ATG Prescreen (not the new Primary Screen folder created above):
+
+```
+./afvs_train_ml_classifier.py --scenario-name gk_ds1 --model-out atg-ml-classifier.pt
+```
+
+By default this reads `../output-files/<docking scenario name>.ranking.complete.csv.gz`, i.e. the Ligand Ranking File produced by `afvs_postprocess_atg-prescreen.sh` in the previous section.
+
+Then pass the trained model to `afvs_prepare_atg-primary-screen-folders.sh` as an additional argument, before creating the Primary Screen folders:
+
+```
+./afvs_prepare_atg-primary-screen-folders.sh screening_sizes:10000 replica_counts:1 qvina02 ml_classifier_model:atg-ml-classifier.pt
+```
+
+This scores every ligand of every tranche-selected collection (not just the sparse sample docked during the ATG Prescreen) and keeps only the ones predicted to have a binding probability greater than 0.5. This cutoff can be adjusted with an additional `ml_classifier_cutoff:<value>` argument. The new Primary Screen folder's `all.ctrl` is automatically configured to dock only the ML-selected ligands (listed in `tools/templates/atg-ml-selected-ligands.csv`) rather than the full tranche-selected todo file that is otherwise used.
+
+Training and applying the classifier both require PyTorch and RDKit installed on this host/login instance. Run `./afvs_train_ml_classifier.py --help` or `./afvs_apply_ml_classifier_atg-primaryscreen.py --help` for the full list of options.
+

--- a/tutorials/tutorial-2-afvs-on-slurm/preparing-the-atg-primary-screen.md
+++ b/tutorials/tutorial-2-afvs-on-slurm/preparing-the-atg-primary-screen.md
@@ -29,3 +29,25 @@ Then we prepare the workflow in the same way as we did for the ATG Prescreen:
 
 The command ./afvs\_prepare\_workunits.py will print the total number of work units. Please remember this number, as it is needed in the next section.&#x20;
 
+## Optional: ML Tranche-Prioritization Classifier
+
+Instead of docking every ligand of every tranche-selected collection, you can optionally train a machine learning classifier on the ATG Prescreen's docking results and use it to keep, within each selected collection, only the ligands it predicts are worth docking. This can substantially reduce the number of ligands actually docked in the ATG Primary Screen.
+
+First, train the classifier on the postprocessed ATG Prescreen results. This is a one-time, host-side command that only takes seconds to run (no Slurm job needed), to be run in the `tools` folder of the ATG Prescreen (not the new Primary Screen folder created above):
+
+```
+./afvs_train_ml_classifier.py --scenario-name gk_ds1 --source slurm --model-out atg-ml-classifier.pt
+```
+
+Unlike the AWS/Athena postprocessing path, the Slurm path has no single combined "ranking.complete" file, so `--source slurm` reads the raw per-collection summary files directly (`../output-files/<docking scenario name>/csv/**/*.csv.gz`, the same files `afvs_postprocess_atg-prescreen.sh` itself reads).
+
+Then pass the trained model to `afvs_prepare_atg-primary-screen-folders.sh` as an additional argument, before creating the Primary Screen folders:
+
+```
+./afvs_prepare_atg-primary-screen-folders.sh screening_sizes:10000 replica_counts:1 qvina02 ml_classifier_model:atg-ml-classifier.pt
+```
+
+This scores every ligand of every tranche-selected collection (not just the sparse sample docked during the ATG Prescreen) and keeps only the ones predicted to have a binding probability greater than 0.5. This cutoff can be adjusted with an additional `ml_classifier_cutoff:<value>` argument. The new Primary Screen folder's `all.ctrl` is automatically configured to dock only the ML-selected ligands (listed in `tools/templates/atg-ml-selected-ligands.csv`) rather than the full tranche-selected todo file that is otherwise used.
+
+Training and applying the classifier both require PyTorch and RDKit installed on this host/login instance. Run `./afvs_train_ml_classifier.py --help` or `./afvs_apply_ml_classifier_atg-primaryscreen.py --help` for the full list of options.
+


### PR DESCRIPTION
## Summary

Adds an optional machine learning classifier to the ATG-VS (Adaptive Target-Guided Virtual Screening) pipeline. After tranches/collections are selected for the ATG Primary Screen, this classifier scores every ligand in each selected collection (not just the sparse sample docked during the ATG Prescreen) and keeps only the ones predicted worth docking, which can substantially reduce the number of ligands actually docked.

The classifier is a fully-connected network over 1024-bit/radius-2 Morgan fingerprints (1024-512-256-128-1, ReLU/ReLU/ReLU/Sigmoid), trained on the ATG Prescreen's own docking results (top-25% most-negative scores labeled positive, with majority-class undersampling).

- `tools/templates/ml_classifier.py`: the classifier itself -- model definition, training (Adam, BCE loss, early stopping), atomic save/load, and batched inference.
- `tools/afvs_train_ml_classifier.py`: one-shot host-side CLI that trains the classifier on postprocessed ATG Prescreen results (supports both the AWS/Athena ranking file and the raw Slurm per-collection summary CSVs).
- `tools/afvs_apply_ml_classifier_atg-primaryscreen.py`: fetches each tranche-selected collection's full ligand set -- reusing `afvs_run.py`'s own `unpack_item()`/`get_attrs()` and `afvs_prepare_workunits.py`'s collection-addressing helpers directly rather than reimplementing them -- and writes a `csv_collection_key_ligand`-format ligand list. This is an existing, already-supported `collection_list_type` in `all.ctrl`, so no changes are needed to the docking engine (`afvs_run.py`) itself.
- `afvs_prepare_atg-primary-screen-folders.sh`: two new optional trailing arguments, `ml_classifier_model:<path>` and `ml_classifier_cutoff:<value>`, following the script's existing prefix-tagged argument convention. When omitted, behavior is unchanged.
- `docker/Dockerfile`: adds the CPU-only torch wheel and rdkit, the classifier's only new dependencies.
- Tutorial docs (`tutorials/tutorial-1-afvs-on-aws` and `tutorial-2-afvs-on-slurm`, `preparing-the-atg-primary-screen.md`): usage instructions for training and applying the classifier.

